### PR TITLE
Shorten authPrefix() method

### DIFF
--- a/src/main/java/lol/hub/pocketbase/AuthRole.java
+++ b/src/main/java/lol/hub/pocketbase/AuthRole.java
@@ -8,6 +8,6 @@ public enum AuthRole {
     }
 
     public String authPrefix() {
-        return this.name().substring(0, 1).toUpperCase() + this.name().substring(1).toLowerCase() + " ";
+        return this.toString();
     }
 }


### PR DESCRIPTION
* Use `toString()` instead of `this.name().substring(0, 1).toUpperCase() + this.name().substring(1).toLowerCase() + " "`